### PR TITLE
Block configured production script to work with development version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .AppleDouble
 .LSOverride
 Icon
+*.swp
 
 # Thumbnails
 ._*

--- a/manifest.json
+++ b/manifest.json
@@ -26,10 +26,18 @@
     ],
     "background": {
         "scripts": ["background.js"],
-        "persistent": false
+        "persistent": true
     },
     "content_security_policy":
         "script-src 'self' 'unsafe-eval'; object-src 'self'; img-src * data: 'self' 'unsafe-eval'",
     "offline_enabled": true,
-    "permissions": ["tabs", "<all_urls>", "activeTab"]
+    "permissions": [
+        "webRequest",
+        "webRequestBlocking",
+        "storage",
+        "http://*/",
+        "https://*/",
+        "tabs",
+        "activeTab"
+    ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 2,
-    "name": "chrome-extension-template",
+    "name": "cp-integrator",
     "version": "0.0.1",
     "description": "Chrome extension boilerplate, replace all values!",
     "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,14 @@
     "manifest_version": 2,
     "name": "cp-integrator",
     "version": "0.0.1",
-    "description": "Chrome extension boilerplate, replace all values!",
+    "description": "Integrates Car Pricing widget into a site",
     "icons": {
         "16": "16x16.png",
         "48": "48x48.png",
         "128": "128x128.png"
     },
     "browser_action": {
-        "default_title": "Boilerplate popup!",
+        "default_title": "Car Pricing",
         "default_popup": "popup.html"
     },
     "content_scripts": [

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,25 +1,12 @@
-import { getBlockScriptUrl, BLOCK_SCRIPT_KEY } from './storage';
+import { getBlacklistSync } from './storage';
 
-//
-// blocking api callback must be sync, because of that
-// we prepare the blocking value in the global space,
-// and continuously track changes in the storage
-//
-let blockScriptUrl = '';
-(async () => {
-    blockScriptUrl = await getBlockScriptUrl();
-
-    chrome.storage.onChanged.addListener((changes, ns) => {
-        const blockScriptChanges = changes[BLOCK_SCRIPT_KEY];
-        if (blockScriptChanges) {
-            blockScriptUrl = blockScriptChanges.newValue;
-        }
-    });
-
-})();
+function isBlockedUrl(url) {
+    const blacklist = getBlacklistSync();
+    return blacklist.some((x) => x === url);
+}
 
 function blockProductionScript(details) {
-    if (details.url === blockScriptUrl) {
+    if (isBlockedUrl(details.url)) {
         return { cancel: true };
     }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,0 +1,31 @@
+import { getBlockScriptUrl, BLOCK_SCRIPT_KEY } from './storage';
+
+//
+// blocking api callback must be sync, because of that
+// we prepare the blocking value in the global space,
+// and continuously track changes in the storage
+//
+let blockScriptUrl = '';
+(async () => {
+    blockScriptUrl = await getBlockScriptUrl();
+
+    chrome.storage.onChanged.addListener((changes, ns) => {
+        const blockScriptChanges = changes[BLOCK_SCRIPT_KEY];
+        if (blockScriptChanges) {
+            blockScriptUrl = blockScriptChanges.newValue;
+        }
+    });
+
+})();
+
+function blockProductionScript(details) {
+    if (details.url === blockScriptUrl) {
+        return { cancel: true };
+    }
+}
+
+chrome.webRequest.onBeforeRequest.addListener(
+    blockProductionScript,
+    { urls: ["<all_urls>"] },
+    ["blocking"]
+);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,30 +1,29 @@
 import {
-    getBlockScriptUrl,
-    storageSet,
-    BLOCK_SCRIPT_KEY,
-    DEFAULT_BLOCK_SCRIPT_URL
+    getBlacklist,
+    setBlacklist,
+    DEFAULT_BLACKLIST,
 } from './storage';
 
 window.addEventListener('load', async () => {
-    const blockScriptUrl = await getBlockScriptUrl();
+    const blacklist = await getBlacklist();
 
     const view = getView();
-    view.blockScriptInput.value = blockScriptUrl;
+    view.blacklist.value = blacklist.join('\n');
 
     view.saveButton.addEventListener('click', async () => {
-        let value = view.blockScriptInput.value;
+        let value = view.blacklist.value.split('\n');
         if (!value) {
-            value = DEFAULT_BLOCK_SCRIPT_URL;
-            view.blockScriptInput.value = value;
+            value = DEFAULT_BLACKLIST;
+            view.blacklist.value = value.join('\n');
             console.log('invalid value, use default', value);
         }
-        await storageSet(BLOCK_SCRIPT_KEY, value);
+        await setBlacklist(value);
     });
 });
 
 function getView() {
     return {
-        blockScriptInput: document.getElementById('block-script-input'),
+        blacklist: document.getElementById('blacklist'),
         saveButton: document.getElementById('save-button')
     };
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,0 +1,30 @@
+import {
+    getBlockScriptUrl,
+    storageSet,
+    BLOCK_SCRIPT_KEY,
+    DEFAULT_BLOCK_SCRIPT_URL
+} from './storage';
+
+window.addEventListener('load', async () => {
+    const blockScriptUrl = await getBlockScriptUrl();
+
+    const view = getView();
+    view.blockScriptInput.value = blockScriptUrl;
+
+    view.saveButton.addEventListener('click', async () => {
+        let value = view.blockScriptInput.value;
+        if (!value) {
+            value = DEFAULT_BLOCK_SCRIPT_URL;
+            view.blockScriptInput.value = value;
+            console.log('invalid value, use default', value);
+        }
+        await storageSet(BLOCK_SCRIPT_KEY, value);
+    });
+});
+
+function getView() {
+    return {
+        blockScriptInput: document.getElementById('block-script-input'),
+        saveButton: document.getElementById('save-button')
+    };
+}

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -11,13 +11,9 @@ window.addEventListener('load', async () => {
     view.blacklist.value = blacklist.join('\n');
 
     view.saveButton.addEventListener('click', async () => {
-        let value = view.blacklist.value.split('\n');
-        if (!value) {
-            value = DEFAULT_BLACKLIST;
-            view.blacklist.value = value.join('\n');
-            console.log('invalid value, use default', value);
-        }
-        await setBlacklist(value);
+        const value = view.blacklist.value;
+        const newBlacklist = value ? value.split('\n') : [];
+        await setBlacklist(newBlacklist);
     });
 });
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,0 +1,35 @@
+export const BLOCK_SCRIPT_KEY = 'block-script-url';
+export const DEFAULT_BLOCK_SCRIPT_URL = 'https://cpf.tadam.ai/peugeot/peugeotClub.umd.min.js';
+
+export function storageGet(key) {
+    return new Promise((resolve, reject) => {
+        try {
+            chrome.storage.sync.get([key], (result) => {
+                resolve(result[key]);
+            });
+        } catch (e) {
+            reject(e);
+        }
+    });
+}
+
+export function storageSet(key, value) {
+    return new Promise((resolve, reject) => {
+        try {
+            const kv = { [key]: value };
+            chrome.storage.sync.set(kv, () => {
+                resolve();
+            })
+        } catch (e) {
+            reject(e);
+        }
+    });
+}
+
+export async function getBlockScriptUrl() {
+    const value = await storageGet(BLOCK_SCRIPT_KEY);
+    if (!value) {
+        return DEFAULT_BLOCK_SCRIPT_URL;
+    }
+    return value;
+}

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -1,14 +1,35 @@
 <!doctype html>
 <html style="min-height:auto" >
     <head>
-        <title>chrome-extension-template</title>
+        <title>Cars Pricing Integrator</title>
         <script src="popup.js"></script>
+        <style>
+
+            body {
+                width: 300px;
+                padding: 5px;
+            }
+
+            #save-button {
+                width: 100%;
+                margin-top: 10px;
+            }
+
+            .container {
+                width: 100%;
+            }
+
+            .container input {
+                width: 100%;
+            }
+
+        </style>
     </head>
     <body>
-    </body>
-    <body>
-        <div>
-            <p>Edit this template!</p>
+        <div class="container">
+            <h3>Block production script:</h3>
+            <input id="block-script-input" value=""></input>
         </div>
+        <button id="save-button">Save Changes</button>
     </body>
 </html>

--- a/src/views/popup.html
+++ b/src/views/popup.html
@@ -19,8 +19,11 @@
                 width: 100%;
             }
 
-            .container input {
+            .container textarea {
+                resize: none;
                 width: 100%;
+                height: 10em;
+                -webkit-box-sizing: border-box;
             }
 
         </style>
@@ -28,7 +31,7 @@
     <body>
         <div class="container">
             <h3>Block production script:</h3>
-            <input id="block-script-input" value=""></input>
+            <textarea id="blacklist" value=""></textarea>
         </div>
         <button id="save-button">Save Changes</button>
     </body>


### PR DESCRIPTION
## Description

To prevent double loading of the same Cars Pricing script (from dev env and production) at the same time, we should block loading of the production script from extension that injects development version. This patch implements such logic.